### PR TITLE
Fixed error messages about unset `webhookUrl`

### DIFF
--- a/src/main/java/rudynakodach/github/io/webhookintegrations/Commands/WIActions.java
+++ b/src/main/java/rudynakodach/github/io/webhookintegrations/Commands/WIActions.java
@@ -191,10 +191,10 @@ public class WIActions implements CommandExecutor, TabCompleter {
         }
         commandSender.sendMessage(ChatColor.AQUA + "Analyzing config... To reload the config use /wi reload");
         String message = "auto-update: " + colorBoolean(plugin.getConfig().getBoolean("auto-update"));
-        if (Objects.requireNonNull(plugin.getConfig().getString("webhookUrl")).trim().equalsIgnoreCase("")) {
-            message += "\nwebhookUrl: " + ChatColor.RED + "unset\n";
+        if (Objects.requireNonNull(plugin.getConfig().getString("webhooks.main")).trim().equalsIgnoreCase("")) {
+            message += "\nwebhooks.main: " + ChatColor.RED + "unset\n";
         } else {
-            message += "\nwebhookUrl: " + ChatColor.GREEN + "set\n";
+            message += "\nwebhooks.main: " + ChatColor.GREEN + "set\n";
         }
 
         message += ChatColor.YELLOW + "EVENTS" + ChatColor.WHITE;

--- a/src/main/java/rudynakodach/github/io/webhookintegrations/WebhookActions.java
+++ b/src/main/java/rudynakodach/github/io/webhookintegrations/WebhookActions.java
@@ -52,7 +52,7 @@ public class WebhookActions {
     public void SendAsync(String json) {
         if(!plugin.getConfig().getBoolean("isEnabled")) {return;}
         if(!plugin.getConfig().contains("webhooks.%s".formatted(target))) {
-            plugin.getLogger().log(Level.SEVERE, LanguageConfiguration.get().getLocalizedString("config.noWebhookUrl"));
+            plugin.getLogger().log(Level.SEVERE, LanguageConfiguration.get().getLocalizedString("config.noWebhookUrl").formatted(target));
             return;
         }
 

--- a/src/main/java/rudynakodach/github/io/webhookintegrations/WebhookIntegrations.java
+++ b/src/main/java/rudynakodach/github/io/webhookintegrations/WebhookIntegrations.java
@@ -134,7 +134,7 @@ public final class WebhookIntegrations extends JavaPlugin {
             }
         }
 
-        String webhookUrl = getConfig().getString("webhookUrl");
+        String webhookUrl = getConfig().getString("webhooks.main");
 
         if (webhookUrl == null) {
             getLogger().log(Level.WARNING, language.getLocalizedString("onStart.webhookEmpty"));

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -4,7 +4,7 @@ en_US:
   no-permission: "&cYou don't have permission to do that."
 
   config:
-    noWebhookUrl: "Config doesn't contain a webhookUrl key! Creating a backup of the config file and using /wi config reset is recommended."
+    noWebhookUrl: "Config doesn't contain a webhooks.%s key! Creating a backup of the config file and using /wi config reset is recommended."
 
   update:
     checking: "Checking for updates..."
@@ -14,7 +14,7 @@ en_US:
 
   onStart:
     message: "Thank you for using WebhookIntegrations <3"
-    webhookEmpty: "WebhookURL is empty and cannot be used! Set the value of webhookUrl inside the config.yml file and restart the server or use \"/setUrl <url>\"!"
+    webhookEmpty: "Main WebhookURL is empty and cannot be used! Set the value of webhooks.main inside the config.yml file and restart the server or use \"/setUrl <url>\"!"
     registeringEvents: "Registering events..."
     eventRegisterFinish: "Events registered."
     commandRegisterFinish: "Commands registered."
@@ -73,7 +73,7 @@ pl_PL:
   no-permission: "&cNie masz uprawnień."
 
   config:
-    noWebhookUrl: "Config nie zawiera klucza webhookUrl! Zalecane jest stworzenie kopii zapasowej pliku konfiguracyjnego i użycie /wi config reset confirm"
+    noWebhookUrl: "Config nie zawiera klucza webhooks.%s! Zalecane jest stworzenie kopii zapasowej pliku konfiguracyjnego i użycie /wi config reset confirm"
 
   update:
     checking: "Sprawdzanie aktualizacji..."
@@ -83,7 +83,7 @@ pl_PL:
 
   onStart:
     message: "Dziękuję za korzystanie z WebhookIntegrations <3"
-    webhookEmpty: "Adres Webhooka jest pusty i nie może zostać użyty! Ustaw wartość 'webhookUrl' w configu albo użyj \"/seturl <url>\"!"
+    webhookEmpty: "Adres Webhooka jest pusty i nie może zostać użyty! Ustaw wartość 'webhooks.main' w configu albo użyj \"/seturl <url>\"!"
     registeringEvents: "Rejestrowanie wydarzeń..."
     eventRegisterFinish: "Wydarzenia zarejestrowane."
     commandRegisterFinish: "Komendy zarejestrowane."


### PR DESCRIPTION
… although `webhooks.main` is set in the config file.  
Also fixed the error messages referencing a (now) non-existing "webhookUrl" key.

I think those lines were forgotten with v2.